### PR TITLE
Hook readlink(3) of /self/proc/exe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CC ?= clang
 TERMUX_BASE_DIR ?= /data/data/com.termux/files
 CFLAGS += -Wall -Wextra -Werror -Wshadow -fvisibility=hidden -std=c17
-C_SOURCE := src/termux-exec.c src/exec-variants.c
+C_SOURCE := src/termux-exec.c src/exec-variants.c src/termux-readlink.c
 CLANG_FORMAT := clang-format --sort-includes --style="{ColumnLimit: 120}" $(C_SOURCE) tests/fexecve.c tests/system-uname.c tests/print-argv0.c tests/popen.c
 CLANG_TIDY ?= clang-tidy
 

--- a/src/termux-readlink.c
+++ b/src/termux-readlink.c
@@ -1,0 +1,21 @@
+#define _GNU_SOURCE
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+
+__attribute__((visibility("default"))) ssize_t readlink(const char *restrict pathname, char *restrict buf,
+                                                        size_t bufsiz) {
+  if (strcmp(pathname, "/proc/self/exe") == 0) {
+    const char *termux_self_exe = getenv("TERMUX_EXEC__PROC_SELF_EXE");
+    if (termux_self_exe) {
+      size_t termux_self_exe_len = strlen(termux_self_exe);
+      size_t bytes_to_copy = (termux_self_exe_len < bufsiz) ? termux_self_exe_len : bufsiz;
+      memcpy(buf, termux_self_exe, bytes_to_copy);
+      return bytes_to_copy;
+    }
+  }
+
+  return syscall(SYS_readlinkat, AT_FDCWD, pathname, buf, bufsiz);
+}


### PR DESCRIPTION
Hook `readlink(3)` of `/self/proc/exe` to avoid having to patch so much code (some which might be third party or compiled on-device).